### PR TITLE
Updated the naming convention of the mock lwc and resolving the issue…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vlocityestools",
   "description": "Vlocity ES DevOps Tools",
-  "version": "0.22.12",
+  "version": "0.22.13",
   "author": "Juan Garcia",
   "bugs": "https://github.com/jfgarcia268/vlocity-es_devops_tools/issues",
   "dependencies": {

--- a/src/commands/vlocityestools/sfsource/createmocklwcos.ts
+++ b/src/commands/vlocityestools/sfsource/createmocklwcos.ts
@@ -97,7 +97,7 @@ export default class createMockLWCOS extends SfdxCommand {
           console.log("Error: " + err); 
         }
         if(results.success){
-          AppUtils.log2("Mock LWC Created" + element);
+          AppUtils.log2("Mock LWC Created: " + element);
         } else {
           AppUtils.log2("Error: " + results.errors.message);
         }
@@ -122,7 +122,8 @@ export default class createMockLWCOS extends SfdxCommand {
         if (isLWC){
           //console.log(omniScriptMap);
           //console.log(oSFolderName);
-          var key = oSFolderName.replace(/_/g, "");
+          var key = oSFolderName.replace(/_|-/g, "");
+          key = key[0].toLowerCase() + key.slice(1);
           omniScriptMap[key] = oSFolderName.replace(/_/g, "/");
         }
       }


### PR DESCRIPTION
- Resolved the issue ("**Error: Name: The Lightning Web Component Bundle API Name can only contain underscores and alphanumeric characters. It must be unique, begin with a letter, not include spaces, not end with an underscore, and not contain two consecutive underscores.**")while creating the mock LWC.
- Made changes to match the naming convention of LWC OS with managed package compiler.